### PR TITLE
Add SeqConvertFilter tool for fuzzy-to-strict filter conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,17 @@ The following tools are available through the MCP protocol:
   - Returns: Snapshot of events captured during the wait period (may be empty if no events match)
 
 - **`SignalList`** - List available signals (read-only)
-  - Parameters: 
+  - Parameters:
     - `workspace` (optional): Specific workspace to query
   - Returns: List of signals with their definitions
+
+- **`SeqConvertFilter`** - Convert fuzzy filter to strict filter expression
+  - Parameters:
+    - `fuzzyFilter` (required): Fuzzy search text (e.g., "error", "timeout")
+    - `workspace` (optional): Specific workspace to query
+  - Returns: Strict Seq filter expression for use in `SeqSearch`
+  - Use case: Help users write correct filter expressions
+  - Example: Convert "error" to a proper Seq filter expression
 
 ## Claude Desktop Integration
 

--- a/src/SeqMcpServer/Mcp/SeqTools.cs
+++ b/src/SeqMcpServer/Mcp/SeqTools.cs
@@ -144,4 +144,65 @@ public static class SeqTools
             throw;
         }
     }
+
+    /// <summary>
+    /// Convert a fuzzy filter expression to a strict Seq filter expression.
+    /// </summary>
+    /// <remarks>
+    /// Seq supports both "fuzzy" filters (like typing in the UI search box) and "strict" filters
+    /// (formal filter expressions). This tool converts fuzzy filters to strict ones, helping users
+    /// write correct filter expressions. For example, "error" becomes a proper filter expression.
+    /// The result includes whether the filter was interpreted as a text search and the reason if so.
+    /// </remarks>
+    /// <param name="fac">Factory for creating Seq connections</param>
+    /// <param name="fuzzyFilter">The fuzzy filter expression to convert (e.g., "error", "timeout")</param>
+    /// <param name="workspace">Optional workspace identifier for multi-tenant scenarios</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Conversion result including the strict expression and metadata about the conversion</returns>
+    [McpServerTool, Description("Convert a fuzzy filter expression to a strict Seq filter expression. Helps write correct filters for SeqSearch.")]
+    public static async Task<object> SeqConvertFilter(
+        SeqConnectionFactory fac,
+        [Required] string fuzzyFilter,
+        string? workspace = null,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var conn = fac.Create(workspace);
+            var result = await conn.Expressions.ToStrictAsync(fuzzyFilter, cancellationToken: ct);
+
+            if (result == null)
+            {
+                return new
+                {
+                    strictExpression = fuzzyFilter,
+                    matchedAsText = false,
+                    reasonIfMatchedAsText = (string?)null
+                };
+            }
+
+            // Return all useful fields from ExpressionPart
+            return new
+            {
+                strictExpression = result.StrictExpression ?? fuzzyFilter,
+                matchedAsText = result.MatchedAsText,
+                reasonIfMatchedAsText = result.ReasonIfMatchedAsText
+            };
+        }
+        catch (OperationCanceledException)
+        {
+            // Return original filter on cancellation
+            return new
+            {
+                strictExpression = fuzzyFilter,
+                matchedAsText = false,
+                reasonIfMatchedAsText = (string?)null
+            };
+        }
+        catch (Exception)
+        {
+            // Re-throw to let MCP handle the error
+            throw;
+        }
+    }
 }

--- a/src/SeqMcpServer/Mcp/SeqTools.cs
+++ b/src/SeqMcpServer/Mcp/SeqTools.cs
@@ -4,8 +4,20 @@ using Seq.Api.Model.Signals;
 using SeqMcpServer.Services;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
 
 namespace SeqMcpServer.Mcp;
+
+/// <summary>
+/// Result of converting a fuzzy filter expression to a strict Seq filter expression.
+/// </summary>
+/// <param name="StrictExpression">The strict filter expression (the original input if no conversion was needed).</param>
+/// <param name="MatchedAsText">True if Seq interpreted the input as a free-text search rather than a filter expression.</param>
+/// <param name="ReasonIfMatchedAsText">Explanation of why the input was interpreted as text, or null when it wasn't.</param>
+public sealed record SeqConvertFilterResult(
+    [property: JsonPropertyName("strictExpression")] string StrictExpression,
+    [property: JsonPropertyName("matchedAsText")] bool MatchedAsText,
+    [property: JsonPropertyName("reasonIfMatchedAsText"), JsonIgnore(Condition = JsonIgnoreCondition.Never)] string? ReasonIfMatchedAsText);
 
 /// <summary>
 /// MCP tools for interacting with Seq structured logging server.
@@ -189,7 +201,7 @@ public static class SeqTools
     /// <param name="ct">Cancellation token</param>
     /// <returns>Conversion result including the strict expression and metadata about the conversion</returns>
     [McpServerTool, Description("Convert a fuzzy filter expression to a strict Seq filter expression. Helps write correct filters for SeqSearch.")]
-    public static async Task<object> SeqConvertFilter(
+    public static async Task<SeqConvertFilterResult> SeqConvertFilter(
         SeqConnectionFactory fac,
         [Required] string fuzzyFilter,
         string? workspace = null,
@@ -202,31 +214,18 @@ public static class SeqTools
 
             if (result == null)
             {
-                return new
-                {
-                    strictExpression = fuzzyFilter,
-                    matchedAsText = false,
-                    reasonIfMatchedAsText = (string?)null
-                };
+                return new SeqConvertFilterResult(fuzzyFilter, false, null);
             }
 
-            // Return all useful fields from ExpressionPart
-            return new
-            {
-                strictExpression = result.StrictExpression ?? fuzzyFilter,
-                matchedAsText = result.MatchedAsText,
-                reasonIfMatchedAsText = result.ReasonIfMatchedAsText
-            };
+            return new SeqConvertFilterResult(
+                result.StrictExpression ?? fuzzyFilter,
+                result.MatchedAsText,
+                result.ReasonIfMatchedAsText);
         }
         catch (OperationCanceledException)
         {
             // Return original filter on cancellation
-            return new
-            {
-                strictExpression = fuzzyFilter,
-                matchedAsText = false,
-                reasonIfMatchedAsText = (string?)null
-            };
+            return new SeqConvertFilterResult(fuzzyFilter, false, null);
         }
         catch (Exception)
         {

--- a/src/SeqMcpServer/Mcp/SeqTools.cs
+++ b/src/SeqMcpServer/Mcp/SeqTools.cs
@@ -222,14 +222,11 @@ public static class SeqTools
                 result.MatchedAsText,
                 result.ReasonIfMatchedAsText);
         }
-        catch (OperationCanceledException)
-        {
-            // Return original filter on cancellation
-            return new SeqConvertFilterResult(fuzzyFilter, false, null);
-        }
         catch (Exception)
         {
-            // Re-throw to let MCP handle the error
+            // Re-throw to let MCP handle the error. Unlike the list-returning tools in this
+            // file, there is no unambiguous "empty" SeqConvertFilterResult value, so cancellation
+            // also propagates rather than being swallowed.
             throw;
         }
     }

--- a/src/SeqMcpServer/SeqMcpServer.csproj
+++ b/src/SeqMcpServer/SeqMcpServer.csproj
@@ -12,9 +12,9 @@
     
     <!-- Package Metadata -->
     <PackageId>SeqMcpServer</PackageId>
-    <Version>0.1.2</Version>
-    <AssemblyVersion>0.1.2.0</AssemblyVersion>
-    <FileVersion>0.1.2.0</FileVersion>
+    <Version>0.1.3</Version>
+    <AssemblyVersion>0.1.3.0</AssemblyVersion>
+    <FileVersion>0.1.3.0</FileVersion>
     <Authors>willibrandon</Authors>
     <Description>MCP server that enables AI assistants to query Seq logs using natural language</Description>
     <PackageProjectUrl>https://github.com/willibrandon/seq-mcp-server</PackageProjectUrl>

--- a/tests/SeqMcpServer.Tests/McpToolsIntegrationTests.cs
+++ b/tests/SeqMcpServer.Tests/McpToolsIntegrationTests.cs
@@ -292,8 +292,12 @@ public abstract class McpToolsIntegrationTestsBase : IAsyncLifetime
         Assert.False(result.IsError);
 
         var contentJson = JsonSerializer.Serialize(result.Content.First());
-        Assert.Contains("\"matchedAsText\":true", contentJson);
-        Assert.Contains("reasonIfMatchedAsText", contentJson);
+        using var outer = JsonDocument.Parse(contentJson);
+        var innerText = outer.RootElement.GetProperty("text").GetString();
+        Assert.NotNull(innerText);
+        using var inner = JsonDocument.Parse(innerText);
+        Assert.True(inner.RootElement.GetProperty("matchedAsText").GetBoolean());
+        Assert.False(string.IsNullOrEmpty(inner.RootElement.GetProperty("reasonIfMatchedAsText").GetString()));
     }
 
     private async Task WriteTestEventAsync(string messageTemplate, string propertyName, bool propertyValue)

--- a/tests/SeqMcpServer.Tests/McpToolsIntegrationTests.cs
+++ b/tests/SeqMcpServer.Tests/McpToolsIntegrationTests.cs
@@ -202,11 +202,58 @@ public class McpToolsIntegrationTests : IAsyncLifetime
         // Act - List available tools via MCP
         var tools = await _mcpClient!.ListToolsAsync();
 
-        // Assert - Should have our three tools
+        // Assert - Should have our four tools
         Assert.NotNull(tools);
         Assert.Contains(tools, t => t.Name == "SeqSearch");
         Assert.Contains(tools, t => t.Name == "SeqWaitForEvents");
         Assert.Contains(tools, t => t.Name == "SignalList");
-        Assert.Equal(3, tools.Count);
+        Assert.Contains(tools, t => t.Name == "SeqConvertFilter");
+        Assert.Equal(4, tools.Count);
+    }
+
+    [Fact]
+    public async Task SeqConvertFilter_ConvertsFilterSuccessfully()
+    {
+        // Act - Convert a fuzzy filter to strict
+        var result = await _mcpClient!.CallToolAsync(
+            "SeqConvertFilter",
+            new Dictionary<string, object?>
+            {
+                ["fuzzyFilter"] = "error"
+            });
+
+        // Assert - Should return a converted filter with all three fields
+        Assert.NotNull(result);
+        Assert.NotNull(result.Content);
+        Assert.True(result.Content.Any());
+        Assert.False(result.IsError);
+
+        // Serialize the content to JSON string to verify structure
+        var contentJson = JsonSerializer.Serialize(result.Content.First());
+        Assert.Contains("strictExpression", contentJson);
+        Assert.Contains("matchedAsText", contentJson);
+        Assert.Contains("reasonIfMatchedAsText", contentJson);
+    }
+
+    [Fact]
+    public async Task SeqConvertFilter_WithTextSearch_ReturnsMetadata()
+    {
+        // Act - Convert a fuzzy filter that will be treated as text search
+        var result = await _mcpClient!.CallToolAsync(
+            "SeqConvertFilter",
+            new Dictionary<string, object?>
+            {
+                ["fuzzyFilter"] = "error timeout" // Invalid syntax, will be text search
+            });
+
+        // Assert - Should return result with matchedAsText=true and reason
+        Assert.NotNull(result);
+        Assert.NotNull(result.Content);
+        Assert.True(result.Content.Any());
+        Assert.False(result.IsError);
+
+        var contentJson = JsonSerializer.Serialize(result.Content.First());
+        Assert.Contains("\"matchedAsText\":true", contentJson);
+        Assert.Contains("reasonIfMatchedAsText", contentJson);
     }
 }

--- a/tests/SeqMcpServer.Tests/McpToolsIntegrationTests.cs
+++ b/tests/SeqMcpServer.Tests/McpToolsIntegrationTests.cs
@@ -250,42 +250,24 @@ public abstract class McpToolsIntegrationTestsBase : IAsyncLifetime
         Assert.Equal(4, tools.Count);
     }
 
-    [Fact]
-    public async Task SeqConvertFilter_ConvertsFilterSuccessfully()
+    [Theory]
+    // Bareword and invalid syntax fall back to text-match
+    [InlineData("error", "\"error\"", true)]
+    [InlineData("error timeout", "\"error timeout\"", true)]
+    // Already-strict filter expressions pass through unchanged
+    [InlineData("@Level = 'Error'", "@Level = 'Error'", false)]
+    [InlineData("Application = 'foo'", "Application = 'foo'", false)]
+    // Fuzzy-but-valid expression gets normalized (== becomes =)
+    [InlineData("User=='alice'", "User = 'alice'", false)]
+    public async Task SeqConvertFilter_ReturnsExpectedResult(string fuzzyFilter, string expectedStrict, bool expectedMatchedAsText)
     {
-        // Act - Convert a fuzzy filter to strict
         var result = await _mcpClient!.CallToolAsync(
             "SeqConvertFilter",
             new Dictionary<string, object?>
             {
-                ["fuzzyFilter"] = "error"
+                ["fuzzyFilter"] = fuzzyFilter
             });
 
-        // Assert - Should return a converted filter with all three fields
-        Assert.NotNull(result);
-        Assert.NotNull(result.Content);
-        Assert.True(result.Content.Any());
-        Assert.False(result.IsError);
-
-        // Serialize the content to JSON string to verify structure
-        var contentJson = JsonSerializer.Serialize(result.Content.First());
-        Assert.Contains("strictExpression", contentJson);
-        Assert.Contains("matchedAsText", contentJson);
-        Assert.Contains("reasonIfMatchedAsText", contentJson);
-    }
-
-    [Fact]
-    public async Task SeqConvertFilter_WithTextSearch_ReturnsMetadata()
-    {
-        // Act - Convert a fuzzy filter that will be treated as text search
-        var result = await _mcpClient!.CallToolAsync(
-            "SeqConvertFilter",
-            new Dictionary<string, object?>
-            {
-                ["fuzzyFilter"] = "error timeout" // Invalid syntax, will be text search
-            });
-
-        // Assert - Should return result with matchedAsText=true and reason
         Assert.NotNull(result);
         Assert.NotNull(result.Content);
         Assert.True(result.Content.Any());
@@ -296,8 +278,12 @@ public abstract class McpToolsIntegrationTestsBase : IAsyncLifetime
         var innerText = outer.RootElement.GetProperty("text").GetString();
         Assert.NotNull(innerText);
         using var inner = JsonDocument.Parse(innerText);
-        Assert.True(inner.RootElement.GetProperty("matchedAsText").GetBoolean());
-        Assert.False(string.IsNullOrEmpty(inner.RootElement.GetProperty("reasonIfMatchedAsText").GetString()));
+
+        Assert.Equal(expectedStrict, inner.RootElement.GetProperty("strictExpression").GetString());
+        Assert.Equal(expectedMatchedAsText, inner.RootElement.GetProperty("matchedAsText").GetBoolean());
+
+        var reason = inner.RootElement.GetProperty("reasonIfMatchedAsText").GetString();
+        Assert.Equal(expectedMatchedAsText, !string.IsNullOrEmpty(reason));
     }
 
     private async Task WriteTestEventAsync(string messageTemplate, string propertyName, bool propertyValue)

--- a/tests/SeqMcpServer.Tests/McpToolsIntegrationTests.cs
+++ b/tests/SeqMcpServer.Tests/McpToolsIntegrationTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
 using Microsoft.Extensions.Configuration;


### PR DESCRIPTION
Add new MCP tool that converts fuzzy filter expressions to strict Seq filter syntax. This helps users write better filter expressions by accepting natural language searches (like "error" or "timeout") and converting them to proper Seq filter expressions.

The tool returns:
- strictExpression: The converted filter expression
- matchedAsText: Whether it was interpreted as a text search
- reasonIfMatchedAsText: Explanation if treated as text search

Includes tests for both successful conversions and text search fallbacks.