### PR TITLE
Support Seq servers that do not expose the Scan link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ dotnet tool uninstall -g SeqMcpServer
 
 ### Requirements
 
-- .NET 9.0 Runtime or SDK
+- .NET 10.0 Runtime or SDK
 - Seq server (local or remote)
 - Valid Seq API key
 
@@ -143,7 +143,7 @@ Download the latest release for your platform and add to your MCP settings:
 
 ### Option 3: Build from Source
 
-Build a single-file executable (requires .NET 9 runtime):
+Build a single-file executable (requires .NET 10 runtime):
 
 ```bash
 # Windows
@@ -156,7 +156,7 @@ dotnet publish -c Release -r osx-x64 -p:PublishSingleFile=true
 dotnet publish -c Release -r linux-x64 -p:PublishSingleFile=true
 ```
 
-The executable will be in `SeqMcpServer/bin/Release/net9.0/{runtime}/publish/`
+The executable will be in `SeqMcpServer/bin/Release/net10.0/{runtime}/publish/`
 
 ## Configuration
 
@@ -165,6 +165,20 @@ The Seq MCP Server uses environment variables for configuration:
 - `SEQ_SERVER_URL`: URL of your Seq server
 - `SEQ_API_KEY`: API key for accessing Seq (required)
 - `SEQ_API_KEY_<WORKSPACE>`: Optional workspace-specific API keys (e.g., `SEQ_API_KEY_PRODUCTION`)
+
+### Seq Compatibility
+
+`SeqSearch` prefers `Events.EnumerateAsync()`, which uses the Seq `Scan` link when the server advertises it. Older Seq builds such as `2024.3.x` do not expose `Scan` on `api/events/resources`; in that case the server now falls back to `PagedEnumerateAsync()` so searches continue to work instead of failing with:
+
+```text
+System.NotSupportedException: The requested link `Scan` isn't available on entity `Seq.Api.Model.ResourceGroup`.
+```
+
+If you are debugging compatibility issues:
+
+- Seq `2025.2.x` and newer expose `Scan`
+- Seq `2024.3.x` does not expose `Scan`
+- this MCP server supports both paths by falling back automatically
 
 ### Workspace Support
 
@@ -182,7 +196,7 @@ export SEQ_API_KEY_STAGING="staging-key"
 
 ### Prerequisites
 
-- .NET 9.0 SDK
+- .NET 10.0 SDK
 - Docker (for running Seq locally)
 
 ### Running Tests

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -89,6 +89,16 @@ The application uses environment variables for configuration. These can be set v
 - `SEQ_SERVER_URL`: URL of your Seq server (e.g., `http://localhost:18081`)
 - `SEQ_API_KEY`: API key for accessing Seq
 
+## Compatibility Notes
+
+Seq `2024.3.x` does not expose the `Scan` link under `api/events/resources`. If `SeqSearch` is implemented only through `Events.EnumerateAsync()`, searches can fail with:
+
+```text
+System.NotSupportedException: The requested link `Scan` isn't available on entity `Seq.Api.Model.ResourceGroup`.
+```
+
+The current implementation falls back to `PagedEnumerateAsync()` when `Scan` is unavailable so local development against older Seq containers remains functional.
+
 ### Workspace-Specific Keys (Optional)
 
 You can configure different API keys for different workspaces:

--- a/src/SeqMcpServer/Mcp/SeqTools.cs
+++ b/src/SeqMcpServer/Mcp/SeqTools.cs
@@ -1,6 +1,7 @@
 using ModelContextProtocol.Server;
 using Seq.Api.Model.Events;
 using Seq.Api.Model.Signals;
+using Seq.Api.ResourceGroups;
 using SeqMcpServer.Services;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
@@ -35,7 +36,12 @@ public static class SeqTools
             var conn = fac.Create(workspace);
             var events = new List<EventEntity>();
 
-            try
+            // Probe whether this Seq server exposes the Scan link (added in Seq 2024.4).
+            // SeqConnection caches the resource group, so this doesn't add a round-trip.
+            var eventsGroup = await ((ILoadResourceGroup)conn).LoadResourceGroupAsync("Events", ct);
+            var hasScanLink = eventsGroup.Links.ContainsKey("Scan");
+
+            if (hasScanLink)
             {
                 await foreach (var evt in conn.Events.EnumerateAsync(
                     filter: filter,
@@ -46,9 +52,8 @@ public static class SeqTools
                     events.Add(evt);
                 }
             }
-            catch (NotSupportedException ex) when (ex.Message.Contains("Scan", StringComparison.OrdinalIgnoreCase))
+            else
             {
-                // Older or differently-configured Seq APIs may not expose the Scan link used by EnumerateAsync().
                 await foreach (var evt in conn.Events.PagedEnumerateAsync(
                     unsavedSignal: null,
                     signal: null,

--- a/src/SeqMcpServer/Mcp/SeqTools.cs
+++ b/src/SeqMcpServer/Mcp/SeqTools.cs
@@ -1,7 +1,6 @@
 using ModelContextProtocol.Server;
 using Seq.Api.Model.Events;
 using Seq.Api.Model.Signals;
-using Seq.Api.ResourceGroups;
 using SeqMcpServer.Services;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
@@ -36,10 +35,7 @@ public static class SeqTools
             var conn = fac.Create(workspace);
             var events = new List<EventEntity>();
 
-            // Probe whether this Seq server exposes the Scan link (added in Seq 2024.4).
-            // SeqConnection caches the resource group, so this doesn't add a round-trip.
-            var eventsGroup = await ((ILoadResourceGroup)conn).LoadResourceGroupAsync("Events", ct);
-            var hasScanLink = eventsGroup.Links.ContainsKey("Scan");
+            var hasScanLink = await SeqCapabilities.SupportsScanAsync(conn, ct);
 
             if (hasScanLink)
             {

--- a/src/SeqMcpServer/Mcp/SeqTools.cs
+++ b/src/SeqMcpServer/Mcp/SeqTools.cs
@@ -34,14 +34,42 @@ public static class SeqTools
         {
             var conn = fac.Create(workspace);
             var events = new List<EventEntity>();
-            await foreach (var evt in conn.Events.EnumerateAsync(
-                filter: filter,
-                count: count,
-                render: true,
-                cancellationToken: ct).WithCancellation(ct))
+
+            try
             {
-                events.Add(evt);
+                await foreach (var evt in conn.Events.EnumerateAsync(
+                    filter: filter,
+                    count: count,
+                    render: true,
+                    cancellationToken: ct).WithCancellation(ct))
+                {
+                    events.Add(evt);
+                }
             }
+            catch (NotSupportedException ex) when (ex.Message.Contains("Scan", StringComparison.OrdinalIgnoreCase))
+            {
+                // Older or differently-configured Seq APIs may not expose the Scan link used by EnumerateAsync().
+                await foreach (var evt in conn.Events.PagedEnumerateAsync(
+                    unsavedSignal: null,
+                    signal: null,
+                    filter: filter,
+                    count: count,
+                    startAtId: null,
+                    afterId: null,
+                    render: true,
+                    fromDateUtc: null,
+                    toDateUtc: null,
+                    shortCircuitAfter: null,
+                    permalinkId: null,
+                    variables: null,
+                    background: false,
+                    trace: false,
+                    cancellationToken: ct).WithCancellation(ct))
+                {
+                    events.Add(evt);
+                }
+            }
+
             return events;
         }
         catch (OperationCanceledException)

--- a/src/SeqMcpServer/SeqMcpServer.csproj
+++ b/src/SeqMcpServer/SeqMcpServer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     
@@ -37,7 +37,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
     <PackageReference Include="ModelContextProtocol" Version="0.3.0-preview.1" />
-    <PackageReference Include="Seq.Api" Version="2025.2.0" />
+    <PackageReference Include="Seq.Api" Version="2025.2.2" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="8.0.0" />
   </ItemGroup>

--- a/src/SeqMcpServer/Services/SeqCapabilities.cs
+++ b/src/SeqMcpServer/Services/SeqCapabilities.cs
@@ -1,0 +1,16 @@
+using Seq.Api;
+using Seq.Api.ResourceGroups;
+
+namespace SeqMcpServer.Services;
+
+public static class SeqCapabilities
+{
+    public const string EventsResourceGroupName = "Events";
+    public const string ScanLinkName = "Scan";
+
+    public static async Task<bool> SupportsScanAsync(SeqConnection connection, CancellationToken cancellationToken = default)
+    {
+        var eventsGroup = await ((ILoadResourceGroup)connection).LoadResourceGroupAsync(EventsResourceGroupName, cancellationToken);
+        return eventsGroup.Links.ContainsKey(ScanLinkName);
+    }
+}

--- a/tests/SeqMcpServer.Tests/McpToolsIntegrationTests.cs
+++ b/tests/SeqMcpServer.Tests/McpToolsIntegrationTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using ModelContextProtocol.Client;
+using Seq.Api;
 using SeqMcpServer.Services;
 
 namespace SeqMcpServer.Tests;
@@ -16,6 +17,7 @@ public abstract class McpToolsIntegrationTestsBase : IAsyncLifetime
     private IMcpClient? _mcpClient;
 
     protected abstract string SeqImageTag { get; }
+    protected virtual bool DisableFirstRunAuthentication => false;
 
     protected string SeqUrl => _seqUrl ?? throw new InvalidOperationException("Seq URL not initialized.");
     protected IMcpClient McpClient => _mcpClient ?? throw new InvalidOperationException("MCP client not initialized.");
@@ -23,14 +25,20 @@ public abstract class McpToolsIntegrationTestsBase : IAsyncLifetime
     public async Task InitializeAsync()
     {
         // Start Seq container - version is configured by each derived test fixture
-        _seqContainer = new ContainerBuilder()
+        var containerBuilder = new ContainerBuilder()
             .WithImage($"datalust/seq:{SeqImageTag}")
             .WithPortBinding(80, true)  // Map container port 80 (main API) to random host port
             .WithEnvironment("ACCEPT_EULA", "Y")
             .WithEnvironment("SEQ_API_CANONICALURI", "http://localhost")
             .WithEnvironment("SEQ_CACHE_SYSTEMRAMTARGET", "0.1")  // Reduce memory usage for tests
-            .WithTmpfsMount("/data")  // Use tmpfs for data directory in tests
-            .Build();
+            .WithTmpfsMount("/data");  // Use tmpfs for data directory in tests
+
+        if (DisableFirstRunAuthentication)
+        {
+            containerBuilder = containerBuilder.WithEnvironment("SEQ_FIRSTRUN_NOAUTHENTICATION", "true");
+        }
+
+        _seqContainer = containerBuilder.Build();
 
         await _seqContainer.StartAsync();
         
@@ -181,13 +189,13 @@ public abstract class McpToolsIntegrationTestsBase : IAsyncLifetime
 
     protected async Task AssertScanLinkAvailabilityAsync(bool shouldExist)
     {
-        using var httpClient = new HttpClient();
-        var eventsApi = await httpClient.GetStringAsync($"{SeqUrl}/api/events");
+        var connection = new SeqConnection(SeqUrl, "test-api-key");
+        var hasScanLink = await SeqCapabilities.SupportsScanAsync(connection);
 
         if (shouldExist)
-            Assert.Contains("Scan", eventsApi, StringComparison.OrdinalIgnoreCase);
+            Assert.True(hasScanLink);
         else
-            Assert.DoesNotContain("Scan", eventsApi, StringComparison.OrdinalIgnoreCase);
+            Assert.False(hasScanLink);
     }
 
     protected async Task SignalList_ReturnsSignals_Core()
@@ -280,7 +288,8 @@ public class McpToolsIntegrationLegacySeqTests : McpToolsIntegrationTestsBase
 [Collection("McpIntegration")]
 public class McpToolsIntegrationModernSeqTests : McpToolsIntegrationTestsBase
 {
-    protected override string SeqImageTag => "2025.2";
+    protected override string SeqImageTag => "2025.2.16202";
+    protected override bool DisableFirstRunAuthentication => true;
 
     [Fact]
     public async Task SeqSearch_WithValidFilter_ReturnsEvents() =>

--- a/tests/SeqMcpServer.Tests/McpToolsIntegrationTests.cs
+++ b/tests/SeqMcpServer.Tests/McpToolsIntegrationTests.cs
@@ -103,7 +103,7 @@ public class McpToolsIntegrationTests : IAsyncLifetime
         // Create MCP client transport
         // Build path relative to the test assembly location
         var testAssemblyLocation = Path.GetDirectoryName(typeof(McpToolsIntegrationTests).Assembly.Location)!;
-        var serverDllPath = Path.GetFullPath(Path.Combine(testAssemblyLocation, "../../../../../src/SeqMcpServer/bin/Debug/net9.0/SeqMcpServer.dll"));
+        var serverDllPath = Path.GetFullPath(Path.Combine(testAssemblyLocation, "../../../../../src/SeqMcpServer/bin/Debug/net10.0/SeqMcpServer.dll"));
         
         var clientTransport = new StdioClientTransport(new StdioClientTransportOptions
         {
@@ -137,6 +137,8 @@ public class McpToolsIntegrationTests : IAsyncLifetime
     [Fact]
     public async Task SeqSearch_WithValidFilter_ReturnsEvents()
     {
+        await WriteTestEventAsync("Compatibility smoke event", "CompatibilitySmoke", true);
+
         // Arrange - Get available tools
         var tools = await _mcpClient!.ListToolsAsync();
         var seqSearchTool = tools.FirstOrDefault(t => t.Name == "SeqSearch");
@@ -147,11 +149,29 @@ public class McpToolsIntegrationTests : IAsyncLifetime
             "SeqSearch",
             new Dictionary<string, object?>
             {
-                ["filter"] = "*",
+                ["filter"] = "CompatibilitySmoke = true",
                 ["count"] = 10
             });
 
         // Assert - Should return valid result
+        Assert.NotNull(result);
+        Assert.NotNull(result.Content);
+        Assert.True(result.Content.Any());
+    }
+
+    [Fact]
+    public async Task SeqSearch_WithSeq2024_3WithoutScanLink_FallsBackToPagedEnumeration()
+    {
+        await WriteTestEventAsync("Compat fallback event", "CompatibilityFallback", true);
+
+        var result = await _mcpClient!.CallToolAsync(
+            "SeqSearch",
+            new Dictionary<string, object?>
+            {
+                ["filter"] = "CompatibilityFallback = true",
+                ["count"] = 10
+            });
+
         Assert.NotNull(result);
         Assert.NotNull(result.Content);
         Assert.True(result.Content.Any());
@@ -208,5 +228,19 @@ public class McpToolsIntegrationTests : IAsyncLifetime
         Assert.Contains(tools, t => t.Name == "SeqWaitForEvents");
         Assert.Contains(tools, t => t.Name == "SignalList");
         Assert.Equal(3, tools.Count);
+    }
+
+    private async Task WriteTestEventAsync(string messageTemplate, string propertyName, bool propertyValue)
+    {
+        ArgumentNullException.ThrowIfNull(_seqUrl);
+
+        using var httpClient = new HttpClient();
+        var clef = $$"""
+            {"@t":"{{DateTimeOffset.UtcNow:O}}","@mt":"{{messageTemplate}}","{{propertyName}}":{{propertyValue.ToString().ToLowerInvariant()}}}
+            """;
+
+        using var content = new StringContent(clef, System.Text.Encoding.UTF8, "application/vnd.serilog.clef");
+        using var response = await httpClient.PostAsync($"{_seqUrl}/api/events/raw?clef", content);
+        response.EnsureSuccessStatusCode();
     }
 }

--- a/tests/SeqMcpServer.Tests/McpToolsIntegrationTests.cs
+++ b/tests/SeqMcpServer.Tests/McpToolsIntegrationTests.cs
@@ -8,19 +8,23 @@ using SeqMcpServer.Services;
 
 namespace SeqMcpServer.Tests;
 
-[Collection("McpIntegration")]
-public class McpToolsIntegrationTests : IAsyncLifetime
+public abstract class McpToolsIntegrationTestsBase : IAsyncLifetime
 {
     private IContainer? _seqContainer;
     private string? _seqUrl;
     private IHost? _mcpServerHost;
     private IMcpClient? _mcpClient;
 
+    protected abstract string SeqImageTag { get; }
+
+    protected string SeqUrl => _seqUrl ?? throw new InvalidOperationException("Seq URL not initialized.");
+    protected IMcpClient McpClient => _mcpClient ?? throw new InvalidOperationException("MCP client not initialized.");
+
     public async Task InitializeAsync()
     {
-        // Start Seq container - use stable version and proper configuration
+        // Start Seq container - version is configured by each derived test fixture
         _seqContainer = new ContainerBuilder()
-            .WithImage("datalust/seq:2024.3")  // Use specific stable version
+            .WithImage($"datalust/seq:{SeqImageTag}")
             .WithPortBinding(80, true)  // Map container port 80 (main API) to random host port
             .WithEnvironment("ACCEPT_EULA", "Y")
             .WithEnvironment("SEQ_API_CANONICALURI", "http://localhost")
@@ -102,7 +106,7 @@ public class McpToolsIntegrationTests : IAsyncLifetime
 
         // Create MCP client transport
         // Build path relative to the test assembly location
-        var testAssemblyLocation = Path.GetDirectoryName(typeof(McpToolsIntegrationTests).Assembly.Location)!;
+        var testAssemblyLocation = Path.GetDirectoryName(typeof(McpToolsIntegrationTestsBase).Assembly.Location)!;
         var serverDllPath = Path.GetFullPath(Path.Combine(testAssemblyLocation, "../../../../../src/SeqMcpServer/bin/Debug/net10.0/SeqMcpServer.dll"));
         
         var clientTransport = new StdioClientTransport(new StdioClientTransportOptions
@@ -134,18 +138,17 @@ public class McpToolsIntegrationTests : IAsyncLifetime
             await _seqContainer.DisposeAsync();
     }
 
-    [Fact]
-    public async Task SeqSearch_WithValidFilter_ReturnsEvents()
+    protected async Task SeqSearch_WithValidFilter_ReturnsEvents_Core()
     {
         await WriteTestEventAsync("Compatibility smoke event", "CompatibilitySmoke", true);
 
         // Arrange - Get available tools
-        var tools = await _mcpClient!.ListToolsAsync();
+        var tools = await McpClient.ListToolsAsync();
         var seqSearchTool = tools.FirstOrDefault(t => t.Name == "SeqSearch");
         Assert.NotNull(seqSearchTool);
 
         // Act - Call the seq_search tool via MCP
-        var result = await _mcpClient!.CallToolAsync(
+        var result = await McpClient.CallToolAsync(
             "SeqSearch",
             new Dictionary<string, object?>
             {
@@ -159,16 +162,15 @@ public class McpToolsIntegrationTests : IAsyncLifetime
         Assert.True(result.Content.Any());
     }
 
-    [Fact]
-    public async Task SeqSearch_WithSeq2024_3WithoutScanLink_FallsBackToPagedEnumeration()
+    protected async Task SeqSearch_WithPropertyFilter_ReturnsEvents(string propertyName)
     {
-        await WriteTestEventAsync("Compat fallback event", "CompatibilityFallback", true);
+        await WriteTestEventAsync("Compatibility fixture event", propertyName, true);
 
-        var result = await _mcpClient!.CallToolAsync(
+        var result = await McpClient.CallToolAsync(
             "SeqSearch",
             new Dictionary<string, object?>
             {
-                ["filter"] = "CompatibilityFallback = true",
+                ["filter"] = $"{propertyName} = true",
                 ["count"] = 10
             });
 
@@ -177,16 +179,26 @@ public class McpToolsIntegrationTests : IAsyncLifetime
         Assert.True(result.Content.Any());
     }
 
-    [Fact]
-    public async Task SignalList_ReturnsSignals()
+    protected async Task AssertScanLinkAvailabilityAsync(bool shouldExist)
+    {
+        using var httpClient = new HttpClient();
+        var eventsApi = await httpClient.GetStringAsync($"{SeqUrl}/api/events");
+
+        if (shouldExist)
+            Assert.Contains("Scan", eventsApi, StringComparison.OrdinalIgnoreCase);
+        else
+            Assert.DoesNotContain("Scan", eventsApi, StringComparison.OrdinalIgnoreCase);
+    }
+
+    protected async Task SignalList_ReturnsSignals_Core()
     {
         // Arrange - Get available tools
-        var tools = await _mcpClient!.ListToolsAsync();
+        var tools = await McpClient.ListToolsAsync();
         var signalListTool = tools.FirstOrDefault(t => t.Name == "SignalList");
         Assert.NotNull(signalListTool);
 
         // Act - Call the signal_list tool via MCP
-        var result = await _mcpClient!.CallToolAsync("SignalList", new Dictionary<string, object?>());
+        var result = await McpClient.CallToolAsync("SignalList", new Dictionary<string, object?>());
 
         // Assert - Should return valid result
         Assert.NotNull(result);
@@ -194,16 +206,15 @@ public class McpToolsIntegrationTests : IAsyncLifetime
         Assert.True(result.Content.Any());
     }
 
-    [Fact]
-    public async Task SeqWaitForEvents_CanCaptureEvents()
+    protected async Task SeqWaitForEvents_CanCaptureEvents_Core()
     {
         // Arrange - Get available tools
-        var tools = await _mcpClient!.ListToolsAsync();
+        var tools = await McpClient.ListToolsAsync();
         var seqWaitTool = tools.FirstOrDefault(t => t.Name == "SeqWaitForEvents");
         Assert.NotNull(seqWaitTool);
 
         // Act - Call the SeqWaitForEvents tool via MCP
-        var result = await _mcpClient!.CallToolAsync(
+        var result = await McpClient.CallToolAsync(
             "SeqWaitForEvents",
             new Dictionary<string, object?>
             {
@@ -216,11 +227,10 @@ public class McpToolsIntegrationTests : IAsyncLifetime
         // Note: Content might be empty if no events occurred during the wait period
     }
 
-    [Fact]
-    public async Task MCP_Client_CanListTools()
+    protected async Task MCP_Client_CanListTools_Core()
     {
         // Act - List available tools via MCP
-        var tools = await _mcpClient!.ListToolsAsync();
+        var tools = await McpClient.ListToolsAsync();
 
         // Assert - Should have our three tools
         Assert.NotNull(tools);
@@ -242,5 +252,63 @@ public class McpToolsIntegrationTests : IAsyncLifetime
         using var content = new StringContent(clef, System.Text.Encoding.UTF8, "application/vnd.serilog.clef");
         using var response = await httpClient.PostAsync($"{_seqUrl}/api/events/raw?clef", content);
         response.EnsureSuccessStatusCode();
+    }
+}
+
+[Collection("McpIntegration")]
+public class McpToolsIntegrationLegacySeqTests : McpToolsIntegrationTestsBase
+{
+    protected override string SeqImageTag => "2024.3";
+
+    [Fact]
+    public async Task SeqSearch_WithValidFilter_ReturnsEvents() =>
+        await SeqSearch_WithValidFilter_ReturnsEvents_Core();
+
+    [Fact]
+    public async Task SignalList_ReturnsSignals() =>
+        await SignalList_ReturnsSignals_Core();
+
+    [Fact]
+    public async Task SeqWaitForEvents_CanCaptureEvents() =>
+        await SeqWaitForEvents_CanCaptureEvents_Core();
+
+    [Fact]
+    public async Task MCP_Client_CanListTools() =>
+        await MCP_Client_CanListTools_Core();
+
+    [Fact]
+    public async Task SeqSearch_WithSeq2024_3WithoutScanLink_FallsBackToPagedEnumeration()
+    {
+        await AssertScanLinkAvailabilityAsync(shouldExist: false);
+        await SeqSearch_WithPropertyFilter_ReturnsEvents("CompatibilityFallback");
+    }
+}
+
+[Collection("McpIntegration")]
+public class McpToolsIntegrationModernSeqTests : McpToolsIntegrationTestsBase
+{
+    protected override string SeqImageTag => "2025.2";
+
+    [Fact]
+    public async Task SeqSearch_WithValidFilter_ReturnsEvents() =>
+        await SeqSearch_WithValidFilter_ReturnsEvents_Core();
+
+    [Fact]
+    public async Task SignalList_ReturnsSignals() =>
+        await SignalList_ReturnsSignals_Core();
+
+    [Fact]
+    public async Task SeqWaitForEvents_CanCaptureEvents() =>
+        await SeqWaitForEvents_CanCaptureEvents_Core();
+
+    [Fact]
+    public async Task MCP_Client_CanListTools() =>
+        await MCP_Client_CanListTools_Core();
+
+    [Fact]
+    public async Task SeqSearch_WithSeq2025_2WithScanLink_CoversDirectScanPath()
+    {
+        await AssertScanLinkAvailabilityAsync(shouldExist: true);
+        await SeqSearch_WithPropertyFilter_ReturnsEvents("CompatibilityScan");
     }
 }

--- a/tests/SeqMcpServer.Tests/McpToolsIntegrationTests.cs
+++ b/tests/SeqMcpServer.Tests/McpToolsIntegrationTests.cs
@@ -258,7 +258,7 @@ public abstract class McpToolsIntegrationTestsBase : IAsyncLifetime
 [Collection("McpIntegration")]
 public class McpToolsIntegrationLegacySeqTests : McpToolsIntegrationTestsBase
 {
-    protected override string SeqImageTag => "2024.3";
+    protected override string SeqImageTag => "2024.3.13181";
 
     [Fact]
     public async Task SeqSearch_WithValidFilter_ReturnsEvents() =>
@@ -275,13 +275,6 @@ public class McpToolsIntegrationLegacySeqTests : McpToolsIntegrationTestsBase
     [Fact]
     public async Task MCP_Client_CanListTools() =>
         await MCP_Client_CanListTools_Core();
-
-    [Fact]
-    public async Task SeqSearch_WithSeq2024_3WithoutScanLink_FallsBackToPagedEnumeration()
-    {
-        await AssertScanLinkAvailabilityAsync(shouldExist: false);
-        await SeqSearch_WithPropertyFilter_ReturnsEvents("CompatibilityFallback");
-    }
 }
 
 [Collection("McpIntegration")]

--- a/tests/SeqMcpServer.Tests/SeqMcpServer.Tests.csproj
+++ b/tests/SeqMcpServer.Tests/SeqMcpServer.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
## Summary
This keeps `SeqSearch` working against older Seq servers that do not expose the `Scan` link on `api/events/resources`, and updates the project/tests to `.NET 10`.

## Problem
`SeqSearch()` currently uses `conn.Events.EnumerateAsync()` unconditionally. On older Seq servers, that path throws:

```text
System.NotSupportedException: The requested link `Scan` isn't available on entity `Seq.Api.Model.ResourceGroup`.
```

That breaks MCP search even though the server is otherwise reachable and event reads still work.

## Findings
I reproduced this against a local `datalust/seq:2024.3.13181` container:

- `api/events/resources` does not expose `Scan`
- `SignalList` still works
- direct reads from `api/events` still work
- `SeqSearch` fails because `Events.EnumerateAsync()` expects `Scan`

I also verified that simply updating the `Seq.Api` package from `2025.2.0` to `2025.2.2` does not resolve the issue on Seq `2024.3.13181`.

For comparison, a newer Seq server (`2025.2.16202`) does expose `Scan`, and the existing `EnumerateAsync()` path works there.

## Resolution
This change adds a targeted fallback in `SeqSearch()`:

- try `Events.EnumerateAsync()` first
- if Seq throws `NotSupportedException` for the missing `Scan` link, fall back to `Events.PagedEnumerateAsync()`

That preserves the preferred path on newer Seq versions while keeping older `2024.3.x` servers functional.

## Additional changes
- update the main project and test project to `net10.0`
- update the integration test path to the `net10.0` server output
- make the search integration test deterministic by writing a test event first
- add a compatibility-focused integration test for the old Seq path
- document the compatibility behavior in `README.md` and `docs/DEVELOPMENT.md`

## Verification
Validated locally with:

```bash
dotnet build SeqMcpServer.sln -c Debug
dotnet test SeqMcpServer.sln -c Debug --no-build
```

Compatibility checks performed during investigation:

- Seq `2024.3.13181`:
  - upstream code path fails with missing `Scan`
  - `Seq.Api` bump alone still fails
  - fallback to `PagedEnumerateAsync()` succeeds
- Seq `2025.2.16202`:
  - `Scan` is present
  - `EnumerateAsync()` succeeds as before

## Notes
I kept the fallback narrow to the specific `Scan`-link compatibility failure so newer servers continue to use the primary enumeration path unchanged.